### PR TITLE
feat!: require AWS provider v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    if: github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    container: blackbirdcloud/terraform-toolkit:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Terraform test
+        env:
+          TFENV_TERRAFORM_VERSION: latest-allowed
+        run: |
+          terraform init -backend=false
+          terraform test

--- a/.template-version
+++ b/.template-version
@@ -1,2 +1,2 @@
 template: terraform-module-template
-version: v1.2.0
+version: v1.3.0

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ module "account_info" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Resources
 

--- a/example/versions.tf
+++ b/example/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1"

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,0 +1,11 @@
+mock_provider "aws" {
+  mock_data "aws_organizations_organization" {
+    defaults = {
+      roots = [{ id = "r-abcd" }]
+    }
+  }
+}
+
+run "plan" {
+  command = plan
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1"


### PR DESCRIPTION
## What
Requires **AWS provider v6** (`~> 6.0`) in the module (root, submodules, and example).

## Why
Org-wide provider modernization: the newest modules (backup, organization) are already on `~> 6.0`; this sweep brings the rest of the template-aligned fleet to the same bounded constraint. Two-component `~>` is used deliberately — single-component constraints (`~> 5`) have no upper bound.

`terraform init` + `terraform validate` pass against the latest AWS provider 6.x for the root module and all submodules.

## Breaking change
Consumers still on AWS provider 4/5 must stay on the previous module major. This PR carries the `release:major` label so the release automation bumps the major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)